### PR TITLE
PB-3537 added null value instead error

### DIFF
--- a/formatter_json.go
+++ b/formatter_json.go
@@ -27,9 +27,9 @@ func (f *formatterJson) Clone() IFormatter {
 
 func checkForEmptyRaw(params FormatParams) {
 	for key, value := range params {
-		switch valyeTyped := value.(type) {
+		switch valueTyped := value.(type) {
 		case json.RawMessage:
-			if len(valyeTyped) == 0 {
+			if len(valueTyped) == 0 {
 				params[key] = json.RawMessage(`null`)
 			}
 		}

--- a/formatter_json.go
+++ b/formatter_json.go
@@ -13,13 +13,25 @@ type formatterJson struct {
 }
 
 func (f *formatterJson) Format(params FormatParams) (result []byte, err error) {
+	checkForEmptyRaw(params)
 	formatted, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
 	}
-	return []byte(fmt.Sprintf("%s\n", string(formatted))), nil
+	return fmt.Appendf(nil, "%s\n", string(formatted)), nil
 }
 
 func (f *formatterJson) Clone() IFormatter {
 	return &formatterJson{}
+}
+
+func checkForEmptyRaw(params FormatParams) {
+	for key, value := range params {
+		switch valyeTyped := value.(type) {
+		case json.RawMessage:
+			if len(valyeTyped) == 0 {
+				params[key] = json.RawMessage(`null`)
+			}
+		}
+	}
 }

--- a/formatter_json_test.go
+++ b/formatter_json_test.go
@@ -1,6 +1,9 @@
 package loggergo
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,4 +19,63 @@ func TestFormatterJson(t *testing.T) {
 	result, err := formatter.Format(params)
 	assert.Equal(`{"param1":"value1"}`+"\n", string(result))
 	assert.Nil(err)
+}
+
+func Test_formatterJson_Format(t *testing.T) {
+	type args struct {
+		params FormatParams
+	}
+	tests := []struct {
+		name       string
+		f          *formatterJson
+		args       args
+		wantResult []byte
+		wantErr    bool
+	}{
+		{
+			name: "empty jsonRaw",
+			args: args{
+				params: FormatParams{
+					"field_a": json.RawMessage(``),
+				},
+			},
+			f:          &formatterJson{},
+			wantResult: fmt.Appendf(nil, "%s\n", string(json.RawMessage(`{"field_a":null}`))),
+			wantErr:    false,
+		},
+		{
+			name: "non-empty jsonRaw",
+			args: args{
+				params: FormatParams{
+					"field_a": json.RawMessage(`{"a":1}`),
+				},
+			},
+			f:          &formatterJson{},
+			wantResult: fmt.Appendf(nil, "%s\n", string(json.RawMessage(`{"field_a":{"a":1}}`))),
+			wantErr:    false,
+		},
+		{
+			name: "non-empty jsonRaw with none",
+			args: args{
+				params: FormatParams{
+					"field_a": json.RawMessage(`null`),
+				},
+			},
+			f:          &formatterJson{},
+			wantResult: fmt.Appendf(nil, "%s\n", string(json.RawMessage(`{"field_a":null}`))),
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, err := tt.f.Format(tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("formatterJson.Format() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotResult, tt.wantResult) {
+				t.Errorf("formatterJson.Format() = %v, want %v", gotResult, tt.wantResult)
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,9 @@ module github.com/nextmillenniummedia/logger-go
 
 go 1.22.3
 
-require github.com/stretchr/testify v1.9.0
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Fix error for empty json.RawMessage. It causes panic in PBS, id-matcher and possibly in cookie-syncer when some object with json.RawMessage type have empty string (``) instead null value (null) or empty object value (`{}`)